### PR TITLE
fix promotion and duplication of first sub-elements

### DIFF
--- a/Project/Sources/Methods/Tools_XMLToObject.4dm
+++ b/Project/Sources/Methods/Tools_XMLToObject.4dm
@@ -1,7 +1,7 @@
 //%attributes = {"shared":true,"preemptive":"capable"}
-  // $object:=XMLToObject($XML_as_TEXT)
-  // second parameter optional, if passed a collection of property names always to set as collection, not as object
-  // used to convert Structure to XML
+// $object:=XMLToObject($XML_as_TEXT)
+// second parameter optional, if passed a collection of property names always to set as collection, not as object
+// used to convert Structure to XML
 
 C_TEXT:C284($1;$text)
 C_OBJECT:C1216($0;$obj)
@@ -20,20 +20,9 @@ C_TEXT:C284($name)
 If (OK=1)
 	$obj:=New object:C1471
 	
-	  // root
+	// root
 	DOM GET XML ELEMENT NAME:C730($ref;$name)
-	Tools_XMLtoObject_Sub ($obj;$name;$ref;$ref;$col)
-	
-	$subref:=DOM Get first child XML element:C723($ref;$Name;$ElemValue)
-	Tools_XMLtoObject_Sub ($obj;$name;$subref;$ElemValue;$col)
-	
-	While (OK=1)
-		$next_XML_Ref:=DOM Get next sibling XML element:C724($subref;$Name;$ElemValue)
-		$subref:=$next_XML_Ref
-		If (OK=1)
-			Tools_XMLtoObject_Sub ($obj;$name;$next_XML_Ref;$ElemValue;$col)
-		End if 
-	End while 
+	Tools_XMLtoObject_Sub($obj;$name;$ref;$ref;$col)
 	
 	DOM CLOSE XML:C722($ref)
 End if 


### PR DESCRIPTION
the existing method first recursively walks the tree and builds, and then walks it iteratively and builds it again, promoting everything from level 2 to level 1.
this PR removes the iterative phase.